### PR TITLE
README: Update pypi package versions for keras and tf-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ pip install \
   pybullet==3.1.6 \
   scipy==1.7.1 \
   tensorflow==2.6.0 \
-  tensorflow-probability==0.13.0 \
-  tf-agents-nightly==0.10.0.dev20210930 \
+  keras==2.6.0 \
+  tf-agents==0.11.0rc0 \
   tqdm==4.62.2
 ```
 


### PR DESCRIPTION
Avoids collision btw keras and tensorflow version
Avoids collision btw stable and nightly for tensorflow-probability

Resolves #1 (I think)

After using this, I see the following `pip freeze` output:
https://gist.github.com/EricCousineau-TRI/ac6e9943606e6b9f7e335882f7caa350#file-new-pip-freeze-txt

@peteflorence This allowed me to run `./run_tests.sh` with all of 'em passing!