### PR TITLE
step after collecting data

### DIFF
--- a/environments/collect/collect_oracle.py
+++ b/environments/collect/collect_oracle.py
@@ -142,13 +142,13 @@ def main(argv):
       action = oracle_policy.action(time_step,
                                     oracle_policy.get_initial_state(1)).action
 
-      time_step = env.step(action)
-
       if len(episode_data.action) < MAX_EPISODE_RECORD_STEPS:
         episode_data.action.append(
             policy_step.PolicyStep(action=action, state=(), info=()))
         episode_data.time_step.append(time_step)
         episode_data.pybullet_state.append(env.get_pybullet_state())
+
+      time_step = env.step(action)
 
       done = time_step.is_last()
       reward = time_step.reward


### PR DESCRIPTION
in collect_oracle.py, `time_step = env.step(action)` is called before observation is recorded: `episode_data.time_step.append(time_step)`.
I apologize if I misunderstood the implementation. But as far as I can see the implementation, `env.step(action)` returns next TimeStep. Thereby, the action at the current time and the observation at the next time are stored in pairs with the same index.

Wouldn't it be correct to record the state of the system when the action is decided?